### PR TITLE
Import adjustments, bugfixes and new features

### DIFF
--- a/src/Resources/contao/classes/RealEstateCronImporter.php
+++ b/src/Resources/contao/classes/RealEstateCronImporter.php
@@ -87,7 +87,7 @@ class RealEstateCronImporter extends \Frontend
 
         foreach ($syncFiles as $syncFile)
         {
-            if (null === $syncFile['synctime'])
+            if ((null === $syncFile['synctime']) || $syncFile['modified'])
             {
                 $files[] = $syncFile;
             }

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -193,3 +193,4 @@ $GLOBALS['TL_CONFIG']['defaultNumberOfMainAttr'] = '3';
 $GLOBALS['TL_CONFIG']['numberFormatDecimals'] = ',';
 $GLOBALS['TL_CONFIG']['numberFormatThousands'] = '.';
 $GLOBALS['TL_CONFIG']['roomOptions'] = '1,2,3,4,5,6,7,8';
+$GLOBALS['TL_CONFIG']['estateManagerMaxFileSize'] = 3000000;

--- a/src/Resources/contao/data/import_field_formats.php
+++ b/src/Resources/contao/data/import_field_formats.php
@@ -968,5 +968,13 @@ return array
         (
             array('combine', '', '', ' ', '', 'a:2:{i:0;a:2:{s:5:"field";s:3:"ort";s:6:"remove";s:1:"1";}i:1;a:2:{s:5:"field";s:16:"regionalerZusatz";s:6:"remove";s:1:"1";}}', '')
         )
-    )
+    ),
+    array
+    (
+        'field' => array('sicherheitstechnik', '', '', NULL),
+        'actions' => array
+        (
+            array('unserialize', '', '', ', ', '', NULL, '')
+        )
+    ),
 );

--- a/src/Resources/contao/data/import_interface_mappings.php
+++ b/src/Resources/contao/data/import_interface_mappings.php
@@ -24,7 +24,7 @@ return array
     array('tl_contact_person', 'vorname',                  'kontaktperson', 'vorname'),
     array('tl_contact_person', 'titel',                    'kontaktperson', 'titel'),
     array('tl_contact_person', 'position',                 'kontaktperson', 'position'),
-    array('tl_contact_person', 'anrede',                   'kontaktperson', 'anrede'),
+    array('tl_contact_person', 'anrede',                   'kontaktperson', 'anrede', array('text', 'lowercase')),
     array('tl_contact_person', 'anrede_brief',             'kontaktperson', 'anrede_brief'),
     array('tl_contact_person', 'firma',                    'kontaktperson', 'firma'),
     array('tl_contact_person', 'strasse',                  'kontaktperson', 'strasse'),

--- a/src/Resources/contao/dca/tl_contact_person.php
+++ b/src/Resources/contao/dca/tl_contact_person.php
@@ -126,10 +126,10 @@ $GLOBALS['TL_DCA']['tl_contact_person'] = array
             'label'                   => &$GLOBALS['TL_LANG']['tl_contact_person']['anrede'],
             'exclude'                 => true,
             'inputType'               => 'select',
-            'options'                 => array('herr','frau'),
+            'options'                 => array('herr', 'frau', 'firma', 'eheleute', 'familie', 'nicht zutreffend', 'divers'),
             'reference'               => &$GLOBALS['TL_LANG']['tl_contact_person'],
             'eval'                    => array('tl_class'=>'w50'),
-            'sql'                     => "varchar(8) NOT NULL default ''"
+            'sql'                     => "varchar(16) NOT NULL default ''"
         ),
         'firma' => array
         (
@@ -563,15 +563,31 @@ class tl_contact_person extends Contao\Backend
     public function generateSalutation(string $varValue, Contao\DataContainer $dc): string
     {
         // Generate salutation if there is none
-        if ($varValue == '')
+        if ('' == $varValue)
         {
-            if($dc->activeRecord->anrede == 'herr'){
-                $salutation = &$GLOBALS['TL_LANG']['tl_contact_person']['salutationMr'][0];
-            }else{
-                $salutation = &$GLOBALS['TL_LANG']['tl_contact_person']['salutationMrs'][0];
+            $prefix  = &$GLOBALS['TL_LANG']['tl_contact_person']['salutationGlobal'][0];
+            $prefix2 = null;
+
+            switch ($salutation = $dc->activeRecord->anrede)
+            {
+                case 'herr':
+                    $prefix  = &$GLOBALS['TL_LANG']['tl_contact_person']['salutationMr'][0];
+                    $prefix2 = &$GLOBALS['TL_LANG']['tl_contact_person'][$salutation][1];
+                    break;
+
+                case 'frau':
+                    $prefix  = &$GLOBALS['TL_LANG']['tl_contact_person']['salutationMrs'][0];
+                    $prefix2 = &$GLOBALS['TL_LANG']['tl_contact_person'][$salutation][1];
+                    break;
+
+                case 'eheleute':
+                case 'familie':
+                case 'firma':
+                    $prefix2 = &$GLOBALS['TL_LANG']['tl_contact_person'][$salutation][1];
+                    break;
             }
 
-            $varValue = $salutation . ' ' . $GLOBALS['TL_LANG']['tl_contact_person'][$dc->activeRecord->anrede][0] . ' ' . ($dc->activeRecord->titel ? $dc->activeRecord->titel . ' ' : '') . $dc->activeRecord->vorname . ' ' . $dc->activeRecord->name;
+            $varValue = $prefix . ($prefix2 ? ' '. $prefix2 : '') . ' ' . ($dc->activeRecord->titel ? $dc->activeRecord->titel . ' ' : '') . $dc->activeRecord->vorname . ' ' . $dc->activeRecord->name;
         }
 
         return $varValue;

--- a/src/Resources/contao/dca/tl_interface_history.php
+++ b/src/Resources/contao/dca/tl_interface_history.php
@@ -90,6 +90,10 @@ $GLOBALS['TL_DCA']['tl_interface_history'] = array
             'flag'                    => 6,
             'sql'                     => "int(10) unsigned NOT NULL default '0'"
         ),
+        'mtime' => array
+        (
+            'sql'                     => "int(10) unsigned NOT NULL default '0'"
+        ),
         'source' => array
         (
             'label'                   => &$GLOBALS['TL_LANG']['tl_interface_history']['source'],
@@ -116,6 +120,12 @@ $GLOBALS['TL_DCA']['tl_interface_history'] = array
         'text' => array
         (
             'label'                   => &$GLOBALS['TL_LANG']['tl_interface_history']['text'],
+            'search'                  => true,
+            'sql'                     => "text NULL"
+        ),
+        'message' => array
+        (
+            'label'                   => &$GLOBALS['TL_LANG']['tl_interface_history']['message'],
             'search'                  => true,
             'sql'                     => "text NULL"
         ),

--- a/src/Resources/contao/dca/tl_real_estate.php
+++ b/src/Resources/contao/dca/tl_real_estate.php
@@ -219,7 +219,7 @@ $GLOBALS['TL_DCA']['tl_real_estate'] = array
             'sql'                     => "varchar(64) NOT NULL default ''"
         ),
 
-         // Objektkategorien
+        // Objektkategorien
         'nutzungsart' => array
         (
             'label'                     => &$GLOBALS['TL_LANG']['tl_real_estate']['nutzungsart'],
@@ -2272,7 +2272,7 @@ $GLOBALS['TL_DCA']['tl_real_estate'] = array
             'inputType'                 => 'text',
             'search'                    => true,
             'flag'                      => 1,
-            'eval'                      => array('mandatory'=>true, 'maxlength'=>255, 'tl_class'=> 'w50'),
+            'eval'                      => array('maxlength'=>255, 'tl_class'=> 'w50'),
             'sql'                       => "varchar(255) NOT NULL default ''",
         ),
         'objektbeschreibung'  => array
@@ -5238,6 +5238,13 @@ class tl_real_estate extends Contao\Backend
         if (!$varValue)
         {
             $title = $dc->activeRecord !== null ? $dc->activeRecord->objekttitel : $title;
+
+            // Do not generate an alias if no title is given
+            if (empty($title))
+            {
+                return '';
+            }
+
             $varValue = Contao\System::getContainer()->get('contao.slug.generator')->generate($title);
         }
 

--- a/src/Resources/contao/dca/tl_real_estate_config.php
+++ b/src/Resources/contao/dca/tl_real_estate_config.php
@@ -24,7 +24,7 @@ $GLOBALS['TL_DCA']['tl_real_estate_config'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{global_legend},estateManagerAdminEmail;{real_estate_list_legend},defaultSorting,statusTokenNewDisplayDuration,defaultNumberOfMainDetails,defaultNumberOfMainAttr,defaultImage;{provider_contact_legend},defaultContactPersonImage,defaultContactPersonFemaleImage,defaultContactPersonMaleImage;{number_legend:hide},numberFormatDecimals,numberFormatThousands;{filter_config_legend:hide},roomOptions'
+		'default'                     => '{global_legend},estateManagerAdminEmail;{real_estate_list_legend},defaultSorting,statusTokenNewDisplayDuration,defaultNumberOfMainDetails,defaultNumberOfMainAttr,defaultImage;{provider_contact_legend},defaultContactPersonImage,defaultContactPersonFemaleImage,defaultContactPersonMaleImage;{number_legend:hide},numberFormatDecimals,numberFormatThousands;{filter_config_legend:hide},roomOptions;{import_legend:hide},estateManagerMaxFileSize'
 	),
 
 	// Fields
@@ -124,6 +124,13 @@ $GLOBALS['TL_DCA']['tl_real_estate_config'] = array
             'default'                 => '4',
             'inputType'               => 'text',
             'eval'                    => array('mandatory'=>true, 'rgxp'=>'natural', 'tl_class'=>'w50')
+        ),
+        'estateManagerMaxFileSize' => array
+        (
+            'label'                   => &$GLOBALS['TL_LANG']['tl_real_estate_config']['maxFileSize'],
+            'default'                 => '3000000',
+            'inputType'               => 'text',
+            'eval'                    => array('mandatory'=>true, 'rgxp'=>'natural', 'nospace'=>true, 'tl_class'=>'w50')
         ),
 	)
 );

--- a/src/Resources/contao/languages/de/tl_contact_person.xlf
+++ b/src/Resources/contao/languages/de/tl_contact_person.xlf
@@ -13,9 +13,57 @@
         <source>Mr.</source>
         <target>Herr</target>
       </trans-unit>
+      <trans-unit id="tl_contact_person.herr.1">
+        <source>Mr.</source>
+        <target>Herr</target>
+      </trans-unit>
       <trans-unit id="tl_contact_person.frau.0">
         <source>Mrs.</source>
         <target>Frau</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.frau.1">
+        <source>Mrs.</source>
+        <target>Frau</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.firma.0">
+        <source>Company</source>
+        <target>Firma</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.firma.1">
+        <source>Company</source>
+        <target>Firma</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.eheleute.0">
+        <source>Spouses</source>
+        <target>Eheleute</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.eheleute.1">
+        <source>spouses</source>
+        <target>Eheleute</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.familie.0">
+        <source>Family</source>
+        <target>Familie</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.familie.1">
+        <source>family</source>
+        <target>Familie</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.nicht_zutreffend.0">
+        <source>Not applicable</source>
+        <target>Nicht zutreffend</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.nicht_zutreffend.1">
+        <source></source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.divers.0">
+        <source>Diverse</source>
+        <target>Divers</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.divers.1">
+        <source></source>
+        <target></target>
       </trans-unit>
       <trans-unit id="tl_contact_person.salutationMr.0">
         <source>Dear</source>
@@ -24,6 +72,10 @@
       <trans-unit id="tl_contact_person.salutationMrs.0">
         <source>Dear</source>
         <target>Sehr geehrte</target>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.salutationGlobal.0">
+        <source>Dear</source>
+        <target>Guten Tag</target>
       </trans-unit>
 
       <trans-unit id="tl_contact_person.firma.0">

--- a/src/Resources/contao/languages/de/tl_interface_history.xlf
+++ b/src/Resources/contao/languages/de/tl_interface_history.xlf
@@ -9,6 +9,14 @@
                 <source>Date and time of the log entry</source>
                 <target>Datum und Uhrzeit des Eintrags</target>
             </trans-unit>
+            <trans-unit id="tl_interface_history.mtime.0">
+                <source>Modification date</source>
+                <source>Datei-Änderungsdatum</source>
+            </trans-unit>
+            <trans-unit id="tl_interface_history.mtime.1">
+                <source>Date and time of the last file modification</source>
+                <target>Datum und Uhrzeit der letzten Dateiänderung.</target>
+            </trans-unit>
             <trans-unit id="tl_interface_history.source.0">
                 <source>Origin</source>
                 <target>Ursprung</target>
@@ -40,6 +48,14 @@
             <trans-unit id="tl_interface_history.text.1">
                 <source>Details of the log entry</source>
                 <target>Details des Log-Eintrags</target>
+            </trans-unit>
+            <trans-unit id="tl_interface_history.message.0">
+                <source>Message</source>
+                <source>Nachricht</source>
+            </trans-unit>
+            <trans-unit id="tl_interface_history.message.1">
+                <source>Details of the log message</source>
+                <source>Details der Log-Nachricht</source>
             </trans-unit>
             <trans-unit id="tl_interface_history.show.0">
                 <source>Show details</source>

--- a/src/Resources/contao/languages/de/tl_real_estate_config.xlf
+++ b/src/Resources/contao/languages/de/tl_real_estate_config.xlf
@@ -21,6 +21,10 @@
         <source>Provider / Contact Persons</source>
         <target>Anbieter / Kontaktpersonen</target>
       </trans-unit>
+      <trans-unit id="tl_real_estate_config.import_legend">
+        <source>Import</source>
+        <target>Import</target>
+      </trans-unit>
 
       <trans-unit id="tl_real_estate_config.estateManagerAdminEmail.0">
         <source>E-mail address of the technical administrator</source>
@@ -109,6 +113,14 @@
       <trans-unit id="tl_real_estate_config.roomOptions.1">
         <source>Here you can enter a comma separated list of options which should be available for the number of rooms.</source>
         <target>Hier können Sie die eine kommagetrente Liste von Optionen eingeben, die für die Zimmeranzahl zur Verfügung stehen soll.</target>
+      </trans-unit>
+      <trans-unit id="tl_real_estate_config.estateManagerMaxFileSize.0">
+        <source>Maximum image upload file size</source>
+        <target>Maximale Bild-Upload-Dateigröße</target>
+      </trans-unit>
+      <trans-unit id="tl_real_estate_config.estateManagerMaxFileSize.1">
+        <source>Here you can enter the maximum upload file size in bytes (1 MB = 1000 kB = 1000000 byte).</source>
+        <target>Hier können Sie die maximale Upload-Dateigröße in Bytes eingeben (1 MB = 1000 kB = 1000000 Byte).</target>
       </trans-unit>
 
       <trans-unit id="tl_real_estate_config.dateAdded">

--- a/src/Resources/contao/languages/en/tl_contact_person.xlf
+++ b/src/Resources/contao/languages/en/tl_contact_person.xlf
@@ -11,13 +11,58 @@
       <trans-unit id="tl_contact_person.herr.0">
         <source>Mr.</source>
       </trans-unit>
+      <trans-unit id="tl_contact_person.herr.1">
+        <source>Mr.</source>
+      </trans-unit>
       <trans-unit id="tl_contact_person.frau.0">
         <source>Mrs.</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.frau.1">
+        <source>Mrs.</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.herrn.0">
+        <source>Mr.</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.herrn.1">
+        <source>Mr.</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.firma.0">
+        <source>Company</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.firma.1">
+        <source>Company</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.eheleute.0">
+        <source>Spouses</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.eheleute.1">
+        <source>spouses</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.familie.0">
+        <source>Family</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.familie.1">
+        <source>family</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.nicht_zutreffend.0">
+        <source>Not applicable</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.nicht_zutreffend.1">
+        <source></source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.divers.0">
+        <source>Diverse</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.divers.1">
+        <source></source>
       </trans-unit>
       <trans-unit id="tl_contact_person.salutationMr.0">
         <source>Dear</source>
       </trans-unit>
       <trans-unit id="tl_contact_person.salutationMrs.0">
+        <source>Dear</source>
+      </trans-unit>
+      <trans-unit id="tl_contact_person.salutationGlobal.0">
         <source>Dear</source>
       </trans-unit>
 

--- a/src/Resources/contao/languages/en/tl_interface_history.xlf
+++ b/src/Resources/contao/languages/en/tl_interface_history.xlf
@@ -7,6 +7,12 @@
             <trans-unit id="tl_interface_history.tstamp.1">
                 <source>Date and time of the log entry</source>
             </trans-unit>
+            <trans-unit id="tl_interface_history.mtime.0">
+                <source>Modification date</source>
+            </trans-unit>
+            <trans-unit id="tl_interface_history.mtime.1">
+                <source>Date and time of the last file modification</source>
+            </trans-unit>
             <trans-unit id="tl_interface_history.source.0">
                 <source>Origin</source>
             </trans-unit>
@@ -30,6 +36,12 @@
             </trans-unit>
             <trans-unit id="tl_interface_history.text.1">
                 <source>Details of the log entry</source>
+            </trans-unit>
+            <trans-unit id="tl_interface_history.message.0">
+                <source>Message</source>
+            </trans-unit>
+            <trans-unit id="tl_interface_history.message.1">
+                <source>Details of the log message</source>
             </trans-unit>
             <trans-unit id="tl_interface_history.show.0">
                 <source>Show details</source>

--- a/src/Resources/contao/languages/en/tl_real_estate_config.xlf
+++ b/src/Resources/contao/languages/en/tl_real_estate_config.xlf
@@ -17,7 +17,9 @@
       <trans-unit id="tl_real_estate_config.provider_contact_legend">
         <source>Provider / Contact Persons</source>
       </trans-unit>
-
+      <trans-unit id="tl_real_estate_config.import_legend">
+        <source>Import</source>
+      </trans-unit>
       <trans-unit id="tl_real_estate_config.estateManagerAdminEmail.0">
         <source>E-mail address of the technical administrator</source>
       </trans-unit>
@@ -83,6 +85,12 @@
       </trans-unit>
       <trans-unit id="tl_real_estate_config.roomOptions.1">
         <source>Here you can enter a comma separated list of options which should be available for the number of rooms.</source>
+      </trans-unit>
+      <trans-unit id="tl_real_estate_config.estateManagerMaxFileSize.0">
+        <source>Maximum image upload file size</source>
+      </trans-unit>
+      <trans-unit id="tl_real_estate_config.estateManagerMaxFileSize.1">
+        <source>Here you can enter the maximum upload file size in bytes (1 MB = 1000 kB = 1000000 byte).</source>
       </trans-unit>
 
       <trans-unit id="tl_real_estate_config.dateAdded">

--- a/src/Resources/contao/models/InterfaceHistoryModel.php
+++ b/src/Resources/contao/models/InterfaceHistoryModel.php
@@ -19,10 +19,12 @@ use Contao\Model\Collection;
  * @property integer $id
  * @property integer $pid
  * @property integer $tstamp
+ * @property integer $mtime
  * @property string  $source
  * @property string  $action
  * @property string  $username
  * @property string  $text
+ * @property string  $message
  * @property integer $status
  *
  * @method static InterfaceHistoryModel|null findById($id, array $opt=array())
@@ -30,18 +32,22 @@ use Contao\Model\Collection;
  * @method static InterfaceHistoryModel|null findOneBy($col, $val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneByPid($val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneByTstamp($val, array $opt=array())
+ * @method static InterfaceHistoryModel|null findOneByMtime($val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneBySource($val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneByAction($val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneByUsername($val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneByText($val, array $opt=array())
+ * @method static InterfaceHistoryModel|null findOneByMessage($val, array $opt=array())
  * @method static InterfaceHistoryModel|null findOneByStatus($val, array $opt=array())
  *
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByPid($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByTstamp($val, array $opt=array())
+ * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByMtime($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findBySource($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByAction($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByUsername($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByText($val, array $opt=array())
+ * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByMessage($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findByStatus($val, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findMultipleByIds($var, array $opt=array())
  * @method static Collection|InterfaceHistoryModel[]|InterfaceHistoryModel|null findBy($col, $val, array $opt=array())
@@ -50,10 +56,12 @@ use Contao\Model\Collection;
  * @method static integer countById($id, array $opt=array())
  * @method static integer countByPid($val, array $opt=array())
  * @method static integer countByTstamp($val, array $opt=array())
+ * @method static integer countByMtime($val, array $opt=array())
  * @method static integer countBySource($val, array $opt=array())
  * @method static integer countByAction($val, array $opt=array())
  * @method static integer countByUsername($val, array $opt=array())
  * @method static integer countByText($val, array $opt=array())
+ * @method static integer countByMessage($val, array $opt=array())
  * @method static integer countByStatus($val, array $opt=array())
  *
  * @author Daniele Sciannimanica <https://github.com/doishub>

--- a/src/Resources/contao/modules/ExposeModuleContactPerson.php
+++ b/src/Resources/contao/modules/ExposeModuleContactPerson.php
@@ -75,6 +75,7 @@ class ExposeModuleContactPerson extends ExposeModule
                                 $varSingleSrc = Config::get('defaultContactPersonFemaleImage');
                                 break;
                             case 'herr':
+                            case 'herrn':
                                 $varSingleSrc = Config::get('defaultContactPersonMaleImage');
                                 break;
                         }

--- a/src/Resources/contao/templates/backend/be_real_estate_sync.html5
+++ b/src/Resources/contao/templates/backend/be_real_estate_sync.html5
@@ -31,7 +31,7 @@
               <td colspan="1" class="tl_file_list col_status">
                 <div class="list_icon_status" style="background-image:url('bundles/estatemanager/icons/status_<?= $file['status'] ?>.svg')">&nbsp;</div>
               </td>
-              <td colspan="1" class="tl_file_list col_file"><?= $file['file'] ?></td>
+              <td colspan="1" class="tl_file_list col_file"><a href="/<?= $file['file'] ?>" target="_blank" title="<?= $file['message'] ?: 'Download ' . $file['file'] ?>"><?= $file['file'] ?></a></td>
               <td colspan="1" class="tl_file_list col_file_time"><?= date('H:i:s d.m.Y', $file['time']); ?></td>
               <td colspan="1" class="tl_file_list col_file_size"><?= $file['size'] ?></td>
               <td colspan="1" class="tl_file_list col_sync_time"><?= ($file['synctime']) ? date('H:i:s d.m.Y', $file['synctime']) : ''; ?></td>


### PR DESCRIPTION
This Pull request introduces following features and fixes:

_____

<h3>Changes</h3>

#### Alias generation
- do not generate an alias if no title or alias were given https://github.com/contao-estatemanager/core/commit/d107fe713e0ad8ca93bdea7b27482973cf5aead0

#### Fields
- the field ``objekttitel`` is not mandatory anymore https://github.com/contao-estatemanager/core/commit/e26a50e6d66de529f280c7f9c11e1cf395955c7c

#### Import
- change cron importer to check for modified files rather than just checking the filename https://github.com/contao-estatemanager/core/commit/7c99694141d196f28dee2e034fe05f680d09e70b

- the cron importer will not stop completely when a faulty import has been detected https://github.com/contao-estatemanager/core/commit/20ba3e88cb982a310a594650a14d48c78c887558 https://github.com/contao-estatemanager/core/commit/dbe2b61a310572adbd7becc98d7b2279f9a4f763 https://github.com/contao-estatemanager/core/commit/7b28e3d737f6b3be02991e1548441d4f0cdf9ec0 https://github.com/contao-estatemanager/core/commit/21a248b4fe2c9d159afad8ce357cf2ede3c8ff99
  - the cron importer will now log an error in the backend
  - unless a faulty import file has been modified (modification date), it will not be considered by the cronjob anymore
  - updated tl_interface_history to quickly download the broken import file
  - highlight import errors within tl_interface_history
  - show the error message within interface history for better accesibility
  - add download-links to the interface overview 
  - consider partially imported files and save their error messages
  
- enable overriding the maximum image filesize when importing real estate https://github.com/contao-estatemanager/core/commit/5919755d1e496a06aa30b9f9d85bde656807027b
  - added a new option within the general real estate settings

#### Enhancements
- consider new salutations from onOffice, flowfact etc. https://github.com/contao-estatemanager/core/commit/8eebce07f93c67568d9f2728beaba26ce9f74703
  - enable up to ``varchar(16)`` for ``tl_contact_person`` salutations and their letter-salutation
  
____
  
<h3>Bugfixes</h3>

- add ``security system`` formatting when importing field formatting https://github.com/contao-estatemanager/core/commit/501c76bd78315df2e5801d64ba8c45b9ead3010f
  - fixes #181
